### PR TITLE
Implement Threading for Frame Saving and Prediction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+/data/

--- a/README.md
+++ b/README.md
@@ -13,8 +13,18 @@
     ```
 4. Go to your inference server's URL, e.g. `http://localhost:5000`, follow the instruction there to test the API.
 
+Currently, the predicted frame is stored in local directory. Create a directory named `data` in the root directory.
+Inside it, create directories `normal` and `accident` to store the predicted frames.
+
 ## Example
 
 ![Example](https://github.com/zeerafle/cctv-inference/blob/master/example.gif)
+
+## TODO
+
+- [x] Store the predicted frames
+- [ ] Write test
+- [ ] Connect to cloud bucket storage
+- [ ] Actually deploy it
 
 


### PR DESCRIPTION
This pull request introduces threading to the frame saving and prediction process in our Accident Detection Inference API. The changes allow each frame to be saved immediately after prediction, without blocking the prediction process. This is achieved by creating a new thread for the `save_frame` function in the `predictions` function.